### PR TITLE
Serve static files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and to the [CHANGELOG recommendations](http://keepachangelog.com/).
 
 ## CONTENTS
 
+### [0.3.1] - (2021-06)
+- Correction de la publication des fichiers statiques quand le déboguage de django est désactivé
+
 ### [0.3] - (2021-06)
 - Ajout intergiciel de tracking utilisateur
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,10 +57,11 @@ RUN pip install uwsgi
 
 #     apt-get install build-essential -y
 COPY poetry.lock pyproject.toml /app/
-COPY . .
 
 RUN poetry config virtualenvs.create false && \
     poetry install $(test $ENV == "prod" && echo "--no-dev") --no-interaction --no-ansi
+
+COPY . .
 
 # CMD ["bash"]
 CMD ["config/runner.sh"]

--- a/config/runner.sh
+++ b/config/runner.sh
@@ -3,6 +3,8 @@
 # ./manage.py collectstatic --noinput
 export PYTHONPATH=$PYTHONPATH:./lemarche:./config
 ./manage.py collectstatic --noinput
+# Do ? Don't ? No guts, no glory ?
+# ./manage.py migrate
 uwsgi --plugins http,python \
       --http "${HOST}:${PORT}" \
       --module config.wsgi \

--- a/config/settings.py
+++ b/config/settings.py
@@ -38,8 +38,9 @@ TRACKER_HOST = os.environ.get('TRACKER_HOST', 'http://localhost')
 BITOUBI_ENV = os.environ.get('ENV', 'dev')
 
 # Static Files
-STATIC_ROOT = os.path.join(BASE_DIR, "static")
 STATIC_URL = "/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedStaticFilesStorage'
 
 # Application definition
 
@@ -77,6 +78,8 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    # Third-party Middlewares
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     # BITOUBI Middlewares
     "lemarche.tracker.middlewares.TokenVisitMiddleware",
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,14 +13,11 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.conf import settings
-from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("", include("lemarche.api.siaes.urls"))] + static(
-    settings.STATIC_URL, document_root=settings.STATIC_ROOT
-)
+    path("", include("lemarche.api.siaes.urls"))
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -571,10 +571,21 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
+[[package]]
+name = "whitenoise"
+version = "5.2.0"
+description = "Radically simplified static file serving for WSGI applications"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[package.extras]
+brotli = ["brotli"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "174a407751663f726f677f5b49b7f12b98fb933c91129381965276288e7f6385"
+content-hash = "594cb870112b79bffc4fcd2c6638f375411a0778d7fa81a661edfc84eca91186"
 
 [metadata.files]
 anyio = [
@@ -881,4 +892,8 @@ tomlkit = [
 uritemplate = [
     {file = "uritemplate-3.0.1-py2.py3-none-any.whl", hash = "sha256:07620c3f3f8eed1f12600845892b0e036a2420acf513c53f7de0abd911a5894f"},
     {file = "uritemplate-3.0.1.tar.gz", hash = "sha256:5af8ad10cec94f215e3f48112de2022e1d5a37ed427fbd88652fa908f2ab7cae"},
+]
+whitenoise = [
+    {file = "whitenoise-5.2.0-py2.py3-none-any.whl", hash = "sha256:05d00198c777028d72d8b0bbd234db605ef6d60e9410125124002518a48e515d"},
+    {file = "whitenoise-5.2.0.tar.gz", hash = "sha256:05ce0be39ad85740a78750c86a93485c40f08ad8c62a6006de0233765996e5c7"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ psycopg2-binary = "^2.8.6"
 hashids = "^1.3.1"
 flake8 = "^3.9.2"
 httpx = "^0.18.1"
+whitenoise = "^5.2.0"
 
 [tool.poetry.dev-dependencies]
 isort = "^5.8.0"


### PR DESCRIPTION
Ajout de la librairie [whitenoise](http://whitenoise.evans.io/en/stable/) pour fluidifier la publication des fichiers statiques sans mettre en place toute une plomberie pour faire fonctionner le tout aussi bien quand le débogage est engagé ou non.