### PR TITLE
:whale: updated docker compose environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Après création du fichier `env.docker.local`,
 ```bash
  # Démarrage
  > docker-compose up
+ # Après démarrage, le serveur est disponible sur http://localhost:8880/
+
  # Se connecter au containeur django
  > docker exec -it bitoubi_django /bin/bash
 
@@ -104,11 +106,11 @@ Le script [start_docker.sh](./start_docker.sh) permet de lancer les environnemen
 
 ## Utilisation
 
-Une fois lancé, l'api propose plusieurs endpoints et interfaces de documentation (liens vers environnement local) :
+Une fois lancé, l'api propose plusieurs endpoints et interfaces de documentation (liens vers environnement docker-compose, port 8880) :
 
-- Documentation Swaggger/OpenAPI : [/docs](http://localhost:8000/api/docs)
-- Documentation ReDoc : [/redoc](http://localhost:8000/api/redoc)
-- Schema OpenApi3 : [/redoc](http://localhost:8000/api/schema)
+- Documentation Swaggger/OpenAPI : [/docs](http://localhost:8880/api/docs)
+- Documentation ReDoc : [/redoc](http://localhost:8880/api/redoc)
+- Schema OpenApi3 : [/redoc](http://localhost:8880/api/schema)
 
 Tant que faire se peut, la documentation des endpoints se fait dans le code, en visant une bonne lisibilité
 de la documentation autogénérée.

--- a/config/dev/entrypoint.sh
+++ b/config/dev/entrypoint.sh
@@ -13,5 +13,10 @@ while ! pg_isready -h $POSTGRESQL_ADDON_HOST -p $POSTGRESQL_ADDON_PORT; do
 done
 
 export PYTHONPATH=$PYTHONPATH:./lemarche:./config
+
+./manage.py collectstatic --noinput
+./manage.py compress --force
+
 ./manage.py migrate
-./manage.py runserver 0.0.0.0:8000
+
+./manage.py runserver 0.0.0.0:8880

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     env_file:
       - env.docker.local
     ports:
-      - "8880:8000"
+      - "8880:8880"
     depends_on:
       - postgres
     networks:


### PR DESCRIPTION
### Quoi ?

- Mise à jour docker-compose pour permettre l'exécution en local de tout l'environnement

### Pourquoi ?

- Le docker-compose ne reflétait pas encore les dernières modifications
- L'équipe intégration nécessite un environnement simple a instancier et stable

### Comment ?

- Mise à jour des ports utilisés dans la documentation
- Utilisation cohérente des ports utilisés : ceux utilisés par UWSGI et ceux publiés par docker (port `8880`)
- Ajout des commandes nécessaires à la publication de pages statiques dans le script de démarrage
